### PR TITLE
Fixes for initial installation and initial build/test

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "express": "^4.12.3",
     "gulp": "^3.8.11",
     "mocha-phantomjs": "^3.5.3",
-    "phantomjs": "^1.9.16",
+    "phantomjs": "1.9.1 - 1.9.7-15",
     "phantomjs-polyfill": "0.0.1",
     "should": "^5.2.0",
     "source-map-support": "^0.2.10",

--- a/src/entry/main.es6.js
+++ b/src/entry/main.es6.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('babel-core/lib/babel/polyfill');
+require('babel-core/polyfill');
 
 let MyFirstComponent = require('components/MyFirstComponent');
 let React = require('react');

--- a/test/entry/test.js
+++ b/test/entry/test.js
@@ -3,7 +3,7 @@
 /* Polyfills for phantomjs */
 require('console-polyfill');
 require('phantomjs-polyfill');
-require('babel-core/lib/babel/polyfill');
+require('babel-core/polyfill');
 
 /* Test spec files */
 require('my-first-store-spec');


### PR DESCRIPTION
1. `npm install` was failing due to unsatisfied peer dependencies of mocha-phantomjs. mocha-phantomjs seems to require (at least for now) phantomjs 1.9.1 - 1.9.7-15. cdba5b7 resolves this.
2. Building and testing (via `gulp watch`) of the initial skeleton project was failing due to apparent changes to the structure of `babel-core`. 0865bf7 resolves this.
